### PR TITLE
feat: migrate confirmation_modal screen to use i18n

### DIFF
--- a/components/text_area/text_area.go
+++ b/components/text_area/text_area.go
@@ -76,6 +76,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, tea.Batch(cmds...)
 }
 
+// TODO: remove legacy code
 func (m Model) View() string {
 	var lastUpdated string
 	if m.currentItem.DateAdded == m.currentItem.DateUpdated {

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,4 +1,6 @@
 {
+  "yes": "Yes",
+  "no": "No",
   "app_title": "Go Workflows",
   "error_starting_app": "Error starting app: %v",
   "confirm_button_label": "Confirm",

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -1,4 +1,6 @@
 {
+  "yes": "Sim",
+  "no": "Não",
   "app_title": "Go Workflows",
   "error_starting_app": "Erro ao iniciar o aplicativo: %v",
   "confirm_button_label": "Confirmar",

--- a/screens/command_list/methods.go
+++ b/screens/command_list/methods.go
@@ -4,8 +4,8 @@ import (
 	"math"
 
 	tea "github.com/charmbracelet/bubbletea"
-	confirmationmodal "github.com/evertonstz/go-workflows/components/confirmation_modal"
 	"github.com/evertonstz/go-workflows/components/list"
+	"github.com/evertonstz/go-workflows/shared"
 )
 
 func (m Model) GetAllItems() []list.MyItem {
@@ -61,12 +61,10 @@ func (m *Model) SetSize(width, height int, smallWidth bool) {
 	}
 }
 
-func (m *Model) rebuildConfirmationModel(title string, confirm string, cancel string, confirmCmd tea.Cmd, cancelCmd tea.Cmd) {
-	m.confirmationModal = confirmationmodal.NewConfirmationModal(
-		title,
-		confirm,
-		cancel,
-		confirmCmd,
-		cancelCmd,
-	)
+func (m *Model) showDeleteModal() {
+	m.confirmationModal =
+		m.deleteConfirmationModalBuilder(
+			tea.Batch(shared.DeleteCurrentItemCmd(m.list.CurrentItemIndex()), shared.CloseConfirmationModalCmd()),
+			shared.CloseConfirmationModalCmd())
+	m.currentRightPanel = modal
 }

--- a/screens/command_list/model.go
+++ b/screens/command_list/model.go
@@ -55,7 +55,7 @@ func New() Model {
 
 	listModel := list.New()
 	textAreaModel := textarea.New()
-	intialModal := confirmationmodal.NewConfirmationModal("", "", "", nil, nil)
+	initialModal := confirmationmodal.NewConfirmationModal("", "", "", nil, nil)
 	deleteConfirmationModalBuilder := func(confirmCmd, cancelCmd tea.Cmd) confirmationmodal.Model {
 		modal := confirmationmodal.NewConfirmationModal(
 			i18n.Translate("confirm_delete_workflow_message"),
@@ -69,7 +69,7 @@ func New() Model {
 
 	return Model{
 		list:                           listModel,
-		confirmationModal:              intialModal,
+		confirmationModal:              initialModal,
 		deleteConfirmationModalBuilder: deleteConfirmationModalBuilder,
 		textArea:                       textAreaModel,
 		panelsStyle: panelsStyle{

--- a/screens/command_list/update.go
+++ b/screens/command_list/update.go
@@ -26,13 +26,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 		case key.Matches(msg, helpkeys.LisKeys.Delete):
-			m.rebuildConfirmationModel(
-				"Are you sure you want to delete this workflow?",
-				"Yes",
-				"No",
-				tea.Batch(shared.DeleteCurrentItemCmd(m.list.CurrentItemIndex()), shared.CloseConfirmationModalCmd()),
-				shared.CloseConfirmationModalCmd())
-			m.currentRightPanel = modal
+			m.showDeleteModal()
 		}
 	}
 


### PR DESCRIPTION
This pull request introduces improvements to the modal handling system, localization updates, and minor code cleanup. The most significant changes include replacing the legacy confirmation modal logic with a builder-based approach, adding localization for "Yes" and "No" in English and Portuguese, and removing unused imports.

### Modal Handling Improvements:
* [`screens/command_list/model.go`](diffhunk://#diff-54432b2f7ade2744d870b2600b866188a1cf546403de3a6958fafafbc7f6ffd1R30-R35): Added a `confirmationModalBuilder` function to dynamically create modals, including a new `deleteConfirmationModalBuilder` for delete confirmation modals. Integrated the `I18nService` for localized modal messages. [[1]](diffhunk://#diff-54432b2f7ade2744d870b2600b866188a1cf546403de3a6958fafafbc7f6ffd1R30-R35) [[2]](diffhunk://#diff-54432b2f7ade2744d870b2600b866188a1cf546403de3a6958fafafbc7f6ffd1R54-R73)
* [`screens/command_list/methods.go`](diffhunk://#diff-c890b01604c7bce9e4115efd5abce35a541b44dc917609a2069cc21d058be859L64-R69): Replaced the `rebuildConfirmationModel` method with `showDeleteModal`, which uses the `deleteConfirmationModalBuilder` for streamlined modal creation.
* [`screens/command_list/update.go`](diffhunk://#diff-b802c0496fb93d702660dad505800da6289bf91ae305cc12385ef7b43c4e7d05L29-R29): Updated the delete workflow logic to use the new `showDeleteModal` method.

### Localization Updates:
* [`locales/en.json`](diffhunk://#diff-c9218bed23f0aeb93d7e1a7d5f6e1345fae20f4b8692b27fb97fd0f37b3d26d7R2-R3): Added translations for "Yes" and "No" in English.
* [`locales/pt-BR.json`](diffhunk://#diff-46c31e5f95c57f94ce2c5e12330f4ee1019600b2bb7f4e83462fe47df7d4913fR2-R3): Added translations for "Sim" and "Não" in Portuguese.

### Code Cleanup:
* [`screens/command_list/methods.go`](diffhunk://#diff-c890b01604c7bce9e4115efd5abce35a541b44dc917609a2069cc21d058be859L7-R8): Removed unused import for `confirmation_modal`.
* [`components/text_area/text_area.go`](diffhunk://#diff-696ba309a97a84615e62cb2fdf3c3943596a62cbaf1e96cf53d96b166174c12aR79): Added a TODO comment to mark legacy code for removal.